### PR TITLE
Remove stray backquote from analogRead reference page

### DIFF
--- a/Language/Functions/Analog IO/analogRead.adoc
+++ b/Language/Functions/Analog IO/analogRead.adoc
@@ -16,7 +16,7 @@ subCategories: [ "Analog I/O" ]
 
 [float]
 === Description
-Reads the value from the specified analog pin. The Arduino board contains a 6 channel (8 channels on the Mini and Nano, 16 on the Mega), 10-bit analog to digital converter. This means that it will map input voltages between 0 and 5 volts into integer values between 0 and 1023. This yields a resolution between readings of: 5 volts / 1024 units or, .0049 volts (4.9 mV) per unit. The input range and resolution can be changed using link:../analogreference[analogReference()]`.
+Reads the value from the specified analog pin. The Arduino board contains a 6 channel (8 channels on the Mini and Nano, 16 on the Mega), 10-bit analog to digital converter. This means that it will map input voltages between 0 and 5 volts into integer values between 0 and 1023. This yields a resolution between readings of: 5 volts / 1024 units or, .0049 volts (4.9 mV) per unit. The input range and resolution can be changed using link:../analogreference[analogReference()].
 
 It takes about 100 microseconds (0.0001 s) to read an analog input, so the maximum reading rate is about 10,000 times a second.
 [%hardbreaks]


### PR DESCRIPTION
Closes https://github.com/arduino/reference-it/issues/15